### PR TITLE
added options page & configurable separator

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -7,7 +7,7 @@
 
 
   "permissions": [
-    "<all_urls>", "tabs"
+    "<all_urls>", "tabs", "storage"
   ],
   
   "content_scripts": [
@@ -18,6 +18,11 @@
   ],
   "background": {
       "scripts": ["titleurl.js"]
+  },
+	
+  "options_ui": {
+      "page": "options/options.html",
+	  "browser_style": true
   }
   
 

--- a/addon/options/options.html
+++ b/addon/options/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+</head>
+<body>
+	<form id="form">
+		<input type="text" name="separatorField" id="separatorField">
+		</textarea>
+		<label for="separatorField">Character(s) to separate page title and URL</label><br>
+		<button type="submit" id="saveButton">Save</button>
+	</form>
+	<script src="options.js"></script>
+</body>
+</html>

--- a/addon/options/options.js
+++ b/addon/options/options.js
@@ -1,0 +1,27 @@
+function restoreOptions() {
+	var separatorPromise = browser.storage.local.get("separator");
+	separatorPromise.then(setSeparator, onError);
+
+	function setSeparator(result) {
+		if (result.separator) {
+			document.getElementById("separatorField").value = result.separator;
+		} else { // on first install, set separator to "|" and save to storage
+			document.getElementById("separatorField").value = "|";
+			document.getElementById("saveButton").click();
+		}
+	}
+
+	function onError(error) { //reset to default
+		document.getElementById("separatorField").value = "|";
+	}
+}
+
+function saveOptions(e) {
+	e.preventDefault();
+	browser.storage.local.set({
+		separator: document.getElementById("separatorField").value
+	});
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.getElementById("form").addEventListener("submit", saveOptions);

--- a/addon/titleUrlPage.js
+++ b/addon/titleUrlPage.js
@@ -3,6 +3,10 @@ browser.runtime.onMessage.addListener(updateUrl)
 updateUrl()
 
 function updateUrl() {
+	getTitle();
+}
+
+function getTitle() {
 	var url = document.URL;
 
 	url = url.replace(/(https?:\/\/[^\/]*\/)[^:]*/i, "$1");
@@ -17,6 +21,9 @@ function updateUrl() {
 		if (result.separator) {
 			separator = result.separator;
 		}
-		document.title = document.title + " " + separator + " " + url;
+
+		if (document.title.indexOf(url) < 0) {
+			document.title = document.title + " " + separator + " " + url;
+		}		
 	}
 }

--- a/addon/titleUrlPage.js
+++ b/addon/titleUrlPage.js
@@ -3,20 +3,20 @@ browser.runtime.onMessage.addListener(updateUrl)
 updateUrl()
 
 function updateUrl() {
-    var title = getTitle();
-    if(title){
-       document.title = title;
-    }
-}
+	var url = document.URL;
 
-function getTitle(){
-    var url = document.URL;
-    
-    url = url.replace(/(https?:\/\/[^\/]*\/)[^:]*/i,"$1");
-    
-    if(document.title.indexOf(url) < 0){
-        return document.title + " | " + url;
-    } else {
-        return document.title;
-    }
+	url = url.replace(/(https?:\/\/[^\/]*\/)[^:]*/i, "$1");
+
+	if (document.title.indexOf(url) < 0) {
+		var separatorPromise = browser.storage.local.get("separator");
+		separatorPromise.then(updateTitle);
+	}
+
+	function updateTitle(result) {
+		let separator = "|";
+		if (result.separator) {
+			separator = result.separator;
+		}
+		document.title = document.title + " " + separator + " " + url;
+	}
 }


### PR DESCRIPTION
added options to manifest.json
added options.html + options.js. options.html contains a form to change
the default ("|") separator, options.js saves changes to the addons
storage.
Adjusted titleUrlPage.js to work with the customized separator, which
has to be received via promise.

I've left the version number unchanged, and haven't paid attention to locales - only language supported in this PR is English. The options page is kept very simple and could probably use adjustments.
I had to rearrange titleUrlPage.js a bit to work with the storage-promise. Leaving it as title=getTitle() would have always returned undefined, due to the return statement executing faster than the promise.

Hope this is similiar to what you had in mind with #5.