### PR TITLE
activate options 'Save' button only if changes are made

### DIFF
--- a/addon/options/options.html
+++ b/addon/options/options.html
@@ -7,7 +7,7 @@
 	<form id="form">
 		<input type="text" name="separatorField" id="separatorField">
 		<label for="separatorField">Character(s) to separate page title and URL</label><br>
-		<button type="submit" id="saveButton">Save</button>
+		<button type="submit" id="saveButton" disabled="true">Save</button>
 	</form>
 	<script src="options.js"></script>
 </body>

--- a/addon/options/options.js
+++ b/addon/options/options.js
@@ -21,7 +21,13 @@ function saveOptions(e) {
 	browser.storage.local.set({
 		separator: document.getElementById("separatorField").value
 	});
+	document.getElementById("saveButton").disabled = true;
+}
+
+function activateSaveButton() {
+	document.getElementById("saveButton").disabled = false;
 }
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.getElementById("form").addEventListener("submit", saveOptions);
+document.getElementById("separatorField").addEventListener("input", activateSaveButton);


### PR DESCRIPTION
this implements the small UX improvement I mentioned in #6.

The "Save" button is disabled by default and only enabled if the content of the textfield changed. Furthermore it provides feedback to the user that *clicking the button did something* by disabling it again after saving changes.