### PR TITLE
trailing slash to title

### DIFF
--- a/addon/titleUrlPage.js
+++ b/addon/titleUrlPage.js
@@ -23,7 +23,7 @@ function getTitle() {
 			url = url.replace(/(https?:\/\/([^\/]*)\/)[^:]*/i, group);
 
 			if (document.title.indexOf(url) < 0) {
-				document.title = document.title + " " + settings.separator + " " + url;
+				document.title = document.title + " " + settings.separator + " " + url + "/";
 			}		
 		});
 	}


### PR DESCRIPTION
Added a trailing slash to match hostname to only original site. For example "google.com/" but not "google.com.somehost.com/" when using KeePass auto-type.