### PR TITLE
Only react when the URL is changed, not all events

### DIFF
--- a/addon/titleurl.js
+++ b/addon/titleurl.js
@@ -1,6 +1,8 @@
 
 function updateUrl(tabId, changeInfo, tabInfo) {
-    browser.tabs.sendMessage(tabId, {action:"updateUrl"});
+    if (changeInfo.url) {
+        browser.tabs.sendMessage(tabId, {action:"updateUrl"});
+    }
 }
 
 function updateTab(tab, changeInfo, tabInfo) {


### PR DESCRIPTION
From the documentation: When the user navigates to a new URL in a tab, this will typically generate several  onUpdated events as various properties of the tabs.Tab object are updated. This includes the url, but also potentially the title and favIconUrl properties. The status property will cycle through "loading" and "complete".